### PR TITLE
apt-get update should not be on its own line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ MAINTAINER sean.seefried@gmail.com
 #
 run echo "deb http://ftp.au.debian.org/debian stable main" > /etc/apt/sources.list
 run echo "deb-src http://ftp.au.debian.org/debian stable main" >> /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get -y install build-essential ghc git libncurses5-dev cabal-install \
+RUN apt-get update && apt-get -y install build-essential ghc git libncurses5-dev cabal-install \
   llvm-3.0 ca-certificates curl file m4 autoconf zlib1g-dev \
   libgnutls-dev libxml2-dev libgsasl7-dev pkg-config python c2hs
 WORKDIR /root


### PR DESCRIPTION
Putting update on its own line before an install is not that helpful - it allows the update and install to potentially be run significant time spans apart, so you'll install from a stale cache. Instead, put update on the same line as install.
